### PR TITLE
Fixed remaining IcedTea references

### DIFF
--- a/src/parsers/arguments.js
+++ b/src/parsers/arguments.js
@@ -1,6 +1,6 @@
 /*
  * An identifier
- *  In IcedTea
+ *  In Blueberry
  *      (identifier1, identifier 2, ... , identifier n)
  *      ()
  */

--- a/src/parsers/assign.js
+++ b/src/parsers/assign.js
@@ -1,6 +1,6 @@
 /*
  * Assignment
- *  In IcedTea:
+ *  In Blueberry:
  *      a = 1
  *  In PHP:
  *      $a = 1;

--- a/src/parsers/def.js
+++ b/src/parsers/def.js
@@ -1,6 +1,6 @@
 /*
  * A def
- *  In IcedTea
+ *  In Blueberry
  *      def myIdentifier
  *          body
  *      end

--- a/src/parsers/expression.js
+++ b/src/parsers/expression.js
@@ -1,6 +1,6 @@
 /*
  * Expression
- *  In IcedTea:
+ *  In Blueberry:
  *      And, Or
  *      >, <, >=, <=, ==, !=
  *      -, +, *, /

--- a/src/parsers/identifier.js
+++ b/src/parsers/identifier.js
@@ -1,6 +1,6 @@
 /*
  * An identifier
- *  In IcedTea
+ *  In Blueberry
  *      [a-zA-Z] [a-zA-Z_0-9]*
  */
 module.exports = function(obj) {


### PR DESCRIPTION
My other pull request https://github.com/gosukiwi/Blueberry/pull/16 fixed the remaining `<?tea`s in examples.
